### PR TITLE
Feature loan pagination

### DIFF
--- a/src/Core/Loans.Application/Repositories/ILoanRepository.cs
+++ b/src/Core/Loans.Application/Repositories/ILoanRepository.cs
@@ -1,4 +1,6 @@
-﻿using Loans.Domain.Entities;
+﻿using Loans.Application.UseCases.Dtos;
+using Loans.Application.UseCases.GetAllLoans;
+using Loans.Domain.Entities;
 
 namespace Loans.Application.Repositories
 {
@@ -7,6 +9,7 @@ namespace Loans.Application.Repositories
         public Task<List<LoanDomain>> GetAllAsync(CancellationToken cancellationToken);
         public Task<LoanDomain> GetByIdAsync(int loanId, CancellationToken cancellationToken);
         Task CreateAsync(LoanDomain domain, CancellationToken cancellationToken);
-        Task UpdateAsyn(LoanDomain domain, CancellationToken cancellationToken);        
+        Task UpdateAsyn(LoanDomain domain, CancellationToken cancellationToken);
+        Task<PagedList<LoanItemResponse>> GetPagedLoansAsync(PaginationParameters parameters, CancellationToken cancellationToken);
     }
 }

--- a/src/Core/Loans.Application/Repositories/ILoanRepository.cs
+++ b/src/Core/Loans.Application/Repositories/ILoanRepository.cs
@@ -9,6 +9,6 @@ namespace Loans.Application.Repositories
         public Task<LoanDomain> GetByIdAsync(int loanId, CancellationToken cancellationToken);
         Task CreateAsync(LoanDomain domain, CancellationToken cancellationToken);
         Task UpdateAsyn(LoanDomain domain, CancellationToken cancellationToken);
-        Task<PagedList<LoanDomain>> GetPagedLoansAsync(PaginationParameters parameters, CancellationToken cancellationToken);
+        Task<(List<LoanDomain> Loans, int TotalCount)> GetPagedLoansAsync(PaginationParameters parameters, CancellationToken cancellationToken);
     }
 }

--- a/src/Core/Loans.Application/Repositories/ILoanRepository.cs
+++ b/src/Core/Loans.Application/Repositories/ILoanRepository.cs
@@ -1,5 +1,4 @@
 ﻿using Loans.Application.UseCases.Dtos;
-using Loans.Application.UseCases.GetAllLoans;
 using Loans.Domain.Entities;
 
 namespace Loans.Application.Repositories
@@ -10,6 +9,6 @@ namespace Loans.Application.Repositories
         public Task<LoanDomain> GetByIdAsync(int loanId, CancellationToken cancellationToken);
         Task CreateAsync(LoanDomain domain, CancellationToken cancellationToken);
         Task UpdateAsyn(LoanDomain domain, CancellationToken cancellationToken);
-        Task<PagedList<LoanItemResponse>> GetPagedLoansAsync(PaginationParameters parameters, CancellationToken cancellationToken);
+        Task<PagedList<LoanDomain>> GetPagedLoansAsync(PaginationParameters parameters, CancellationToken cancellationToken);
     }
 }

--- a/src/Core/Loans.Application/Services/ServiceExtesions.cs
+++ b/src/Core/Loans.Application/Services/ServiceExtesions.cs
@@ -1,6 +1,7 @@
 ﻿using Loans.Application.UseCases.CreateLoan;
 using Loans.Application.UseCases.GetAllLoans;
 using Loans.Application.UseCases.GetInstallmentsByLoandId;
+using Loans.Application.UseCases.GetLoanByPagination;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 
@@ -14,7 +15,8 @@ namespace Loans.Application.Services
             services.AddAutoMapper(
                 typeof(CreateLoanMapper).Assembly,
                 typeof(GetAllLoansMapper).Assembly,
-                typeof(GetInstallmentsByLoanIdMapper).Assembly
+                typeof(GetInstallmentsByLoanIdMapper).Assembly,
+                typeof(GetLoanByPaginationMapper).Assembly
                 );
 
             services.AddMediatR(cfg =>

--- a/src/Core/Loans.Application/UseCases/Dtos/PagedList.cs
+++ b/src/Core/Loans.Application/UseCases/Dtos/PagedList.cs
@@ -1,0 +1,21 @@
+﻿namespace Loans.Application.UseCases.Dtos
+{
+    public class PagedList<T>
+    {
+        public IReadOnlyList<T> Items { get; }
+        public int PageNumber { get; }
+        public int PageSize { get; }
+        public int TotalCount { get; }
+        public int TotalPages => (int)Math.Ceiling(TotalCount / (double)PageSize);
+        public bool HasPrevious => PageNumber > 1;
+        public bool HasNext => PageNumber < TotalPages;
+
+        public PagedList(IReadOnlyList<T> items, int pageNumber, int pageSize, int totalCount)
+        {
+            Items = items;
+            PageNumber = pageNumber;
+            PageSize = pageSize;
+            TotalCount = totalCount;
+        }
+    }
+}

--- a/src/Core/Loans.Application/UseCases/Dtos/PaginationParameters.cs
+++ b/src/Core/Loans.Application/UseCases/Dtos/PaginationParameters.cs
@@ -1,0 +1,4 @@
+﻿namespace Loans.Application.UseCases.Dtos
+{
+    public record PaginationParameters(int PageNumber = 1, int PageSize = 10);
+}

--- a/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationHandler.cs
+++ b/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationHandler.cs
@@ -1,0 +1,27 @@
+﻿using AutoMapper;
+using Loans.Application.Repositories;
+using Loans.Application.UseCases.Dtos;
+using Loans.Application.UseCases.GetAllLoans;
+using MediatR;
+
+namespace Loans.Application.UseCases.GetLoanByPagination
+{
+    public class GetLoanByPaginationHandler : IRequestHandler<GetLoanByPaginationRequest, PagedList<LoanItemResponse>>
+    {
+        private readonly ILoanRepository _loanRepository;
+        private readonly IMapper _mapper;
+
+        public GetLoanByPaginationHandler(ILoanRepository loanRepository,
+            IMapper mapper)
+        {
+            this._loanRepository = loanRepository;
+            this._mapper = mapper;
+        }
+
+        public async Task<PagedList<LoanItemResponse>> Handle(GetLoanByPaginationRequest request, CancellationToken cancellationToken)
+        {
+            return await _loanRepository.GetPagedLoansAsync(request.Parameters, cancellationToken);
+        }
+
+    }
+}

--- a/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationHandler.cs
+++ b/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationHandler.cs
@@ -20,14 +20,18 @@ namespace Loans.Application.UseCases.GetLoanByPagination
 
         public async Task<PagedList<LoanItemResponse>> Handle(GetLoanByPaginationRequest request, CancellationToken cancellationToken)
         {
-            var pagedDomains = await _loanRepository.GetPagedLoansAsync(request.Parameters, cancellationToken);
-            var Items = _mapper.Map<List<LoanItemResponse>>(pagedDomains.Items);
+            var (loans, totalCount) = await _loanRepository.GetPagedLoansAsync(request.Parameters, cancellationToken);
+            var items = _mapper.Map<List<LoanItemResponse>>(loans);
+            int totalPages = (int)Math.Ceiling(totalCount / (double)request.Parameters.PageSize);
+            int pageNumber = request.Parameters.PageNumber > totalPages ? totalPages : request.Parameters.PageNumber;
+            pageNumber = pageNumber == 0 ? 1 : pageNumber;
+
             var responsePageList = new PagedList<LoanItemResponse>
                 (
-                    Items,
-                    pagedDomains.PageNumber,
-                    pagedDomains.PageSize,
-                    pagedDomains.TotalCount
+                    items,
+                    pageNumber,
+                    totalPages,
+                    totalCount
                 );
 
             return responsePageList;

--- a/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationHandler.cs
+++ b/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationHandler.cs
@@ -20,8 +20,17 @@ namespace Loans.Application.UseCases.GetLoanByPagination
 
         public async Task<PagedList<LoanItemResponse>> Handle(GetLoanByPaginationRequest request, CancellationToken cancellationToken)
         {
-            return await _loanRepository.GetPagedLoansAsync(request.Parameters, cancellationToken);
-        }
+            var pagedDomains = await _loanRepository.GetPagedLoansAsync(request.Parameters, cancellationToken);
+            var Items = _mapper.Map<List<LoanItemResponse>>(pagedDomains.Items);
+            var responsePageList = new PagedList<LoanItemResponse>
+                (
+                    Items,
+                    pagedDomains.PageNumber,
+                    pagedDomains.PageSize,
+                    pagedDomains.TotalCount
+                );
 
+            return responsePageList;
+        }
     }
 }

--- a/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationMapper.cs
+++ b/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationMapper.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Loans.Application.UseCases.GetAllLoans;
+using Loans.Domain.Entities;
+using Loans.Domain.Types;
+
+namespace Loans.Application.UseCases.GetLoanByPagination
+{
+    public class GetLoanByPaginationMapper : Profile
+    {
+        public GetLoanByPaginationMapper()
+        {
+            CreateMap<LoanDomain, LoanItemResponse>()
+                .ForMember(dest => dest.OverdueCount, opt => opt.MapFrom(
+                    src => src.Installments.Count(i => i.Status == InstallmentStatus.Overdue)));
+        }
+    }
+}

--- a/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationMapper.cs
+++ b/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationMapper.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Loans.Application.UseCases.Dtos;
 using Loans.Application.UseCases.GetAllLoans;
 using Loans.Domain.Entities;
 using Loans.Domain.Types;

--- a/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationRequest.cs
+++ b/src/Core/Loans.Application/UseCases/GetLoanByPagination/GetLoanByPaginationRequest.cs
@@ -1,0 +1,16 @@
+﻿using Loans.Application.UseCases.Dtos;
+using Loans.Application.UseCases.GetAllLoans;
+using MediatR;
+
+namespace Loans.Application.UseCases.GetLoanByPagination
+{
+    public class GetLoanByPaginationRequest : IRequest<PagedList<LoanItemResponse>>
+    {
+        public PaginationParameters Parameters { get; }
+
+        public GetLoanByPaginationRequest(PaginationParameters parameters)
+        {
+            Parameters = parameters;
+        }
+    }
+}

--- a/src/Infrastructure/Loans.Infrastructure/Persistance/Repositories/LoanRepository.cs
+++ b/src/Infrastructure/Loans.Infrastructure/Persistance/Repositories/LoanRepository.cs
@@ -1,12 +1,10 @@
 ﻿using AutoMapper;
 using Loans.Application.Repositories;
 using Loans.Application.UseCases.Dtos;
-using Loans.Application.UseCases.GetAllLoans;
 using Loans.Domain.Entities;
 using Loans.Infrastructure.Persistance.Context;
 using Loans.Infrastructure.Persistance.Entities;
 using Microsoft.EntityFrameworkCore;
-using static Loans.Application.UseCases.GetLoanByPagination.GetLoanByPaginationRequest;
 
 namespace Loans.Infrastructure.Persistance.Repositories
 {
@@ -81,7 +79,7 @@ namespace Loans.Infrastructure.Persistance.Repositories
             }
         }
 
-        public async Task<PagedList<LoanItemResponse>> GetPagedLoansAsync
+        public async Task<PagedList<LoanDomain>> GetPagedLoansAsync
             (PaginationParameters parameters, CancellationToken cancellationToken)
         {
             var query = _context.Loans
@@ -95,9 +93,9 @@ namespace Loans.Infrastructure.Persistance.Repositories
                 .Take(parameters.PageSize)
                 .ToListAsync(cancellationToken);
 
-            var items = _mapper.Map<List<LoanItemResponse>>(entities);
+            var items = _mapper.Map<List<LoanDomain>>(entities);
 
-            return new PagedList<LoanItemResponse>(items, parameters.PageNumber, parameters.PageSize, totalCount);
+            return new PagedList<LoanDomain>(items, parameters.PageNumber, parameters.PageSize, totalCount);
         }
     }
 }

--- a/src/Infrastructure/Loans.Infrastructure/Persistance/Repositories/LoanRepository.cs
+++ b/src/Infrastructure/Loans.Infrastructure/Persistance/Repositories/LoanRepository.cs
@@ -79,7 +79,7 @@ namespace Loans.Infrastructure.Persistance.Repositories
             }
         }
 
-        public async Task<PagedList<LoanDomain>> GetPagedLoansAsync
+        public async Task<(List<LoanDomain> Loans, int TotalCount)> GetPagedLoansAsync
             (PaginationParameters parameters, CancellationToken cancellationToken)
         {
             var query = _context.Loans
@@ -93,9 +93,9 @@ namespace Loans.Infrastructure.Persistance.Repositories
                 .Take(parameters.PageSize)
                 .ToListAsync(cancellationToken);
 
-            var items = _mapper.Map<List<LoanDomain>>(entities);
+            var loans = _mapper.Map<List<LoanDomain>>(entities);
 
-            return new PagedList<LoanDomain>(items, parameters.PageNumber, parameters.PageSize, totalCount);
+            return (loans, totalCount);
         }
     }
 }

--- a/src/Presentation/Loans.WebAPI/Controllers/LoanController.cs
+++ b/src/Presentation/Loans.WebAPI/Controllers/LoanController.cs
@@ -1,7 +1,10 @@
 ﻿using Loans.Application.UseCases.CreateLoan;
+using Loans.Application.UseCases.Dtos;
 using Loans.Application.UseCases.GetAllLoans;
+using Loans.Application.UseCases.GetLoanByPagination;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using static Loans.Application.UseCases.GetLoanByPagination.GetLoanByPaginationRequest;
 
 namespace Loans.WebAPI.Controllers
 {
@@ -46,5 +49,22 @@ namespace Loans.WebAPI.Controllers
                 return NotFound(ex.Message);
             }
         }
+
+        [HttpGet("paged")]
+        public async Task<ActionResult<PagedList<LoanItemResponse>>> GetByPagination(
+            [FromQuery] PaginationParameters parameters,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var response = await _mediator.Send(new GetLoanByPaginationRequest(parameters), cancellationToken);
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                return NotFound(ex.Message);
+            }
+        }
+
     }
 }

--- a/src/Presentation/Loans.WebAPI/Controllers/LoanController.cs
+++ b/src/Presentation/Loans.WebAPI/Controllers/LoanController.cs
@@ -4,7 +4,6 @@ using Loans.Application.UseCases.GetAllLoans;
 using Loans.Application.UseCases.GetLoanByPagination;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using static Loans.Application.UseCases.GetLoanByPagination.GetLoanByPaginationRequest;
 
 namespace Loans.WebAPI.Controllers
 {


### PR DESCRIPTION
Changed the repository method to return a tuple with the list of LoanDomain and the total count, instead of a paginated object. This keeps pagination logic in the application layer and maintains clean separation of responsibilities.